### PR TITLE
폰트 목록 마우스오버 이벤트 변경

### DIFF
--- a/src/components/fontbox.tsx
+++ b/src/components/fontbox.tsx
@@ -295,7 +295,7 @@ export default function FontBox({
                         <div
                           aria-label="font-link"
                           key={font.code}
-                          className="w-full group/wrap relative pt-6 lg:pt-8 pb-2 hover:rounded-lg border-t first:border-t-0 last:border-b border-l-b dark:border-d-6 [&+div]:hover:border-t-transparent hover:border-transparent hover:bg-l-e hover:dark:bg-d-4 animate-fade-in-fontbox cursor-pointer"
+                          className="w-full group/wrap relative pt-6 lg:pt-8 pb-2 hover:rounded-lg border-t first:border-t-0 last:border-b border-l-b dark:border-d-6 [&+div]:hover:border-t-transparent hover:border-transparent hover:dark:border-transparent hover:bg-l-e hover:dark:bg-d-4 animate-fade-in-fontbox cursor-pointer"
                         >
                           <Link
                             href={`/post/${font.font_family.replaceAll(


### PR DESCRIPTION
## 변경 사항

- 다크모드에서 폰트 목록 마우스오버 시 테두리 색 제거